### PR TITLE
Fix line-marking faces overriding other faces

### DIFF
--- a/diredfl.el
+++ b/diredfl.el
@@ -331,14 +331,14 @@ In particular, inode number, number of hard links, and file size."
          '(1 diredfl-rare-priv keep))
 
    (list (concat "^\\([^\n " (char-to-string dired-del-marker) "].*$\\)")
-         1 diredfl-flag-mark-line t)     ; Flag/mark lines
+         '(1 diredfl-flag-mark-line append))                           ; Flag/mark lines
    (list (concat "^\\([^\n " (char-to-string dired-del-marker) "]\\)") ; Flags, marks (except D)
-         1 diredfl-flag-mark t)
+         '(1 diredfl-flag-mark append))
 
    (list (concat "^\\([" (char-to-string dired-del-marker) "].*$\\)") ; Deletion-flagged lines
-         1 diredfl-deletion-file-name t)
+         '(1 diredfl-deletion-file-name append))
    (list (concat "^\\([" (char-to-string dired-del-marker) "]\\)") ; Deletion flags (D)
-         1 diredfl-deletion t)
+         '(1 diredfl-deletion append))
 
    ) "2nd level of Dired highlighting.  See `font-lock-maximum-decoration'.")
 


### PR DESCRIPTION
This is especially useful when multiple fonts are used (e.g. for icons, proportional texts).

<img width="1403" alt="marked" src="https://user-images.githubusercontent.com/198359/35968094-728d0a1e-0cf5-11e8-937e-36a760e6dbde.png">
