### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+dist: xenial
+language: emacs-lisp
+addons:
+  apt:
+    update: true
+
+jobs:
+  allow_failures:
+    - env: EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
+  include:
+    - stage: build
+      env:
+        - EVM_EMACS=emacs-24.5-travis
+      script: &build
+        - rm -rf $HOME/.evm
+        - travis_retry eval $"git clone https://github.com/rejeep/evm.git $HOME/.evm ; sleep 10"
+        - export PATH=$HOME/.evm/bin:$HOME/.cask/bin:$PATH
+        - evm config path /tmp
+        - travis_retry eval $"evm install $EVM_EMACS --use --skip ; sleep 10"
+        - emacs --version
+        - travis_retry eval $"curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python ; sleep 10"
+        - travis_retry eval $"cask install ; sleep 10"
+        - cask build
+    - stage: build
+      env:
+        - EVM_EMACS=emacs-25.3-travis
+      script: *build
+    - stage: build
+      env:
+        - EVM_EMACS=emacs-26.3-travis-linux-xenial
+      script: *build
+    - stage: build
+      env:
+        - EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
+      script: *build

--- a/Cask
+++ b/Cask
@@ -1,0 +1,10 @@
+(source gnu)
+(source melpa)
+
+(package-file "diredfl.el")
+
+(development
+ (depends-on "f")
+ (depends-on "ecukes")
+ (depends-on "ert-runner")
+ (depends-on "el-mock"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Melpa Status](http://melpa.org/packages/diredfl-badge.svg)](http://melpa.org/#/diredfl)
 [![Melpa Stable Status](http://stable.melpa.org/packages/diredfl-badge.svg)](http://stable.melpa.org/#/diredfl)
 <a href="https://www.patreon.com/sanityinc"><img alt="Support me" src="https://img.shields.io/badge/Support%20Me-%F0%9F%92%97-ff69b4.svg"></a>
+[![Build Status](https://travis-ci.org/purcell/diredfl.svg?branch=master)](https://travis-ci.org/purcell/diredfl)
 
 # Extra font lock rules for a more colourful dired
 


### PR DESCRIPTION
Travis CI coverage.  Closely copied from Helm: https://github.com/emacs-helm/helm/blob/master/.travis.yml

Succeeds: https://travis-ci.org/peterbecich/diredfl/builds/629573243